### PR TITLE
feat: sort out-of-sync by import order

### DIFF
--- a/make_html.py
+++ b/make_html.py
@@ -164,7 +164,7 @@ class Mathlib3FileData:
     labels: Optional[List[dict[str, str]]]
     dependents: Optional[List['Mathlib3FileData']] = None
     dependencies: Optional[List['Mathlib3FileData']] = None
-    depth: Optional[int] = 0     # `depth` is used for sorting based on the import hierarchy.
+    depth: int = 0     # `depth` is used for sorting based on the import hierarchy.
     forward_port: Optional[ForwardPortInfo] = None
     mathlib4_history: List[FileHistoryEntry] = field(default_factory=list)
 

--- a/make_html.py
+++ b/make_html.py
@@ -164,7 +164,7 @@ class Mathlib3FileData:
     labels: Optional[List[dict[str, str]]]
     dependents: Optional[List['Mathlib3FileData']] = None
     dependencies: Optional[List['Mathlib3FileData']] = None
-    depth: int = 0     # `depth` is used for sorting based on the import hierarchy.
+    dependent_depth: int = 0
     forward_port: Optional[ForwardPortInfo] = None
     mathlib4_history: List[FileHistoryEntry] = field(default_factory=list)
 
@@ -317,7 +317,7 @@ def get_data():
                 # Top-level files that are never imported have depth 0,
                 # all imports of a file have strictly larger depth
                 _g = graph.subgraph(nx.descendants(graph, f_import).union([f_import]))
-                f_data.depth = nx.dag_longest_path_length(_g)
+                f_data.dependent_depth = nx.dag_longest_path_length(_g)
 
                 graph.nodes[f_import]["data"] = f_data
 

--- a/make_html.py
+++ b/make_html.py
@@ -277,6 +277,9 @@ mathlib4_dir = build_dir / 'repos' / 'mathlib4'
 graph = parse_imports(mathlib_dir / 'src')
 graph = nx.transitive_reduction(graph)
 
+# Save topological order to sort by lowest file in import chain.
+topol_order = {node : i  for i, node in enumerate(nx.topological_sort(graph))}
+
 (build_dir / 'html').mkdir(parents=True, exist_ok=True)
 
 shutil.copytree(Path('static'), build_dir / 'html', dirs_exist_ok=True)
@@ -312,6 +315,10 @@ def get_data():
                 f_data.dependencies = [
                     data[k] for k in nx.ancestors(graph, f_import) if k in data
                 ]
+
+                # Save topological order into data.
+                f_data.topol_order = topol_order[f_import] # graph.nodes[f_import]["topol_order"]
+
                 graph.nodes[f_import]["data"] = f_data
 
 

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -50,7 +50,7 @@ $(document).ready(function () {
     let table = elem.DataTable({
         columns: [
             { class: 'dt-control', orderable: false },
-            null, null, null, null,
+            null, null, null, null, null,
         ],
     });
     elem.on('click', 'td.dt-control', function () {
@@ -77,6 +77,7 @@ $(document).ready(function () {
         <th>Verified at</th>
         <th>Mathlib3 changes (newest first)</th>
         <th>&pm;</th>
+        <th>import order</th>
     </thead>
     <tbody>
     {%- for d in needs_sync %}
@@ -102,9 +103,10 @@ $(document).ready(function () {
                 <span style="display: none"></span>
                 <span class="text-success" title="added">+{{added}}</span>&nbsp;<span class="text-danger" title="removed">-{{removed}}</span>
             </td>
+            <td data-order="{{ d.topol_order }}">&nbsp;</td>
         </tr>
         <tr{% if not d.status.ported %} class="table-warning"{% endif %} data-is-child="true">
-            <td colspan="5">
+            <td colspan="6">
                 <pre><code class="language-diff">{{ d.forward_port.diff }}</code></pre>
             </td>
         </tr>

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -77,7 +77,7 @@ $(document).ready(function () {
         <th>Verified at</th>
         <th>Mathlib3 changes (newest first)</th>
         <th>&pm;</th>
-        <th>import depth</th>
+        <th title="Longest chain of mathlib3-files importing this file.">import depth</th>
     </thead>
     <tbody>
     {%- for d in needs_sync %}
@@ -103,7 +103,7 @@ $(document).ready(function () {
                 <span style="display: none"></span>
                 <span class="text-success" title="added">+{{added}}</span>&nbsp;<span class="text-danger" title="removed">-{{removed}}</span>
             </td>
-            <td data-order="{{ -d.depth }}">{{ d.depth }}</td>
+            <td>{{ d.depth }}</td>
         </tr>
         <tr{% if not d.status.ported %} class="table-warning"{% endif %} data-is-child="true">
             <td colspan="6">

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -77,7 +77,7 @@ $(document).ready(function () {
         <th>Verified at</th>
         <th>Mathlib3 changes (newest first)</th>
         <th>&pm;</th>
-        <th>import order</th>
+        <th>import depth</th>
     </thead>
     <tbody>
     {%- for d in needs_sync %}
@@ -103,7 +103,7 @@ $(document).ready(function () {
                 <span style="display: none"></span>
                 <span class="text-success" title="added">+{{added}}</span>&nbsp;<span class="text-danger" title="removed">-{{removed}}</span>
             </td>
-            <td data-order="{{ d.topol_order }}">&nbsp;</td>
+            <td data-order="{{ -d.depth }}">{{ d.depth }}</td>
         </tr>
         <tr{% if not d.status.ported %} class="table-warning"{% endif %} data-is-child="true">
             <td colspan="6">

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -70,14 +70,14 @@ $(document).ready(function () {
     });
 });
 </script>
-<div class="table-responsive"><table class="table table-sm sync-table">
+<div class="table-responsive"><table class="table table-sm sync-table" data-order="[[5, &quot;desc&quot;]]">
     <thead>
         <th></th>
         <th>File</th>
         <th>Verified at</th>
         <th>Mathlib3 changes (newest first)</th>
         <th>&pm;</th>
-        <th title="Longest chain of mathlib3-files importing this file.">import depth</th>
+        <th title="Length of the longest chain of mathlib3 files importing this file.">Import depth</th>
     </thead>
     <tbody>
     {%- for d in needs_sync %}
@@ -103,7 +103,7 @@ $(document).ready(function () {
                 <span style="display: none"></span>
                 <span class="text-success" title="added">+{{added}}</span>&nbsp;<span class="text-danger" title="removed">-{{removed}}</span>
             </td>
-            <td>{{ d.depth }}</td>
+            <td>{{ d.dependent_depth }}</td>
         </tr>
         <tr{% if not d.status.ported %} class="table-warning"{% endif %} data-is-child="true">
             <td colspan="6">


### PR DESCRIPTION
This adds a 6th column to the [out-of-sync list](https://leanprover-community.github.io/mathlib-port-status/out-of-sync) which sorts the entries by import order.

When forward-porting multiple files at once, it can be helpful to start with the ones lowest in the import chain.