### PR TITLE
add list of open PRs which updated a given out-of-sync file.

### DIFF
--- a/make_html.py
+++ b/make_html.py
@@ -292,10 +292,6 @@ def get_data():
             pbar.set_postfix_str(f_import.ljust(max_len), refresh=False)
             path = mathlib_dir / 'src' / Path(*f_import.split('.')).with_suffix('.lean')
 
-            if f_status.mathlib4_sync_prs is None:
-                f_status.mathlib4_sync_prs = []
-            if f_status.labels is None:
-                f_status.labels = []
             for label in f_status.labels:
                 label.text_color = text_color_of_color(label.color)
 

--- a/make_html.py
+++ b/make_html.py
@@ -250,6 +250,13 @@ def link_sha(sha: Union[port_status_yaml.PortStatusEntry.Source, git.Commit], pa
     else:
         return Markup('<span title="Unknown" class="text-danger">???</span>')
 
+def text_color_of_color(color):
+    r, g, b = map(lambda i: int(color[i:i + 2], 16), (0, 2, 4))
+    perceived_lightness = (
+        (r * 0.2126) + (g * 0.7152) + (b * 0.0722)) / 255
+    lightness_threshold = 0.453
+    return 'black' if perceived_lightness > lightness_threshold else 'white'
+
 port_status = port_status_yaml.load()
 
 build_dir = Path('build')
@@ -261,6 +268,7 @@ template_env.filters['htmlify_comment'] = htmlify_comment
 template_env.filters['htmlify_text'] = htmlify_text
 template_env.filters['link_sha'] = link_sha
 template_env.filters['set'] = set
+template_env.filters['text_color_of_color'] = text_color_of_color
 template_env.globals['site_url'] = os.environ.get('SITE_URL', '')
 template_env.globals['PortState'] = PortState
 template_env.globals['nx'] = nx
@@ -318,13 +326,6 @@ def get_data():
         f_data.mathlib4_history = history.get(f_import, [])
 
     return data
-
-def text_color_of_color(color):
-    r, g, b = map(lambda i: int(color[i:i + 2], 16), (0, 2, 4))
-    perceived_lightness = (
-        (r * 0.2126) + (g * 0.7152) + (b * 0.0722)) / 255
-    lightness_threshold = 0.453
-    return 'black' if perceived_lightness > lightness_threshold else 'white'
 
 def make_index(env, html_root):
     data = get_data()

--- a/make_html.py
+++ b/make_html.py
@@ -93,6 +93,7 @@ def github_labels(pr):
               for label in raw_labels]
     return labels
 
+
 def parse_imports(root_path):
     import_re = re.compile(r"^import ([^ ]*)")
 

--- a/make_html.py
+++ b/make_html.py
@@ -138,8 +138,8 @@ class Mathlib3FileData:
     mathlib3_import: List[str]
     status: port_status_yaml.PortStatusEntry
     lines: Optional[int]
-    dependents: List['Mathlib3FileData'] = field(default_factory=list)
-    dependencies: List['Mathlib3FileData'] = field(default_factory=list)
+    dependents: Optional[List['Mathlib3FileData']] = None
+    dependencies: Optional[List['Mathlib3FileData']] = None
     dependent_depth: int = 0
     forward_port: Optional[ForwardPortInfo] = None
     mathlib4_history: List[FileHistoryEntry] = field(default_factory=list)

--- a/make_html.py
+++ b/make_html.py
@@ -184,13 +184,6 @@ class Mathlib3FileData:
         return Path('src', *self.mathlib3_import).with_suffix('.lean')
 
     @functools.cached_property
-    def date_ported(self) -> datetime.datetime:
-        if not self.mathlib4_history:
-            return None
-        else:
-            return datetime.datetime.fromtimestamp(self.mathlib4_history[-1].commit.committed_date, datetime.timezone.utc)
-
-    @functools.cached_property
     def state(self):
         if self.status.ported:
             return PortState.PORTED

--- a/make_html.py
+++ b/make_html.py
@@ -152,17 +152,17 @@ class Mathlib3FileData:
     forward_port: Optional[ForwardPortInfo] = None
     mathlib4_history: List[FileHistoryEntry] = field(default_factory=list)
 
+    @property
+    def mathlib3_file(self) -> Path:
+        # todo: doesn't work for lean3 core
+        return Path('src', *self.mathlib3_import).with_suffix('.lean')
+
     @functools.cached_property
     def date_ported(self) -> datetime.datetime:
         if not self.mathlib4_history:
             return None
         else:
             return datetime.datetime.fromtimestamp(self.mathlib4_history[-1].commit.committed_date, datetime.timezone.utc)
-
-    @property
-    def mathlib3_file(self) -> Path:
-        # todo: doesn't work for lean3 core
-        return Path('src', *self.mathlib3_import).with_suffix('.lean')
 
     @functools.cached_property
     def state(self):
@@ -296,8 +296,9 @@ def get_data():
                 f_status.sync_prs = []
             if f_status.labels is None:
                 f_status.labels = []
-            # Add the text color to the lists from the yaml file which are `[label name, label color]`.
-            f_status.labels = [[*x, text_color_of_color(x[1])] for x in f_status.labels if x]
+            # Add the text color to the dict from the yaml file which has keys `name`, `color`.
+            for label in f_status.labels:
+                label.text_color = text_color_of_color(label.color)
 
             try:
                 with path.open('r') as f_src:

--- a/make_html.py
+++ b/make_html.py
@@ -426,7 +426,6 @@ def make_out_of_sync(env, html_root, mathlib_dir):
                     mathlib4_import=mathlib4_import,
                     data=get_data().get(f_import),
                     graph=graph,
-                    text_color_of_color=text_color_of_color,
                 ):
                     file_f.write(chunk)
 

--- a/make_html.py
+++ b/make_html.py
@@ -138,8 +138,8 @@ class Mathlib3FileData:
     mathlib3_import: List[str]
     status: port_status_yaml.PortStatusEntry
     lines: Optional[int]
-    dependents: Optional[List['Mathlib3FileData']] = None
-    dependencies: Optional[List['Mathlib3FileData']] = None
+    dependents: List['Mathlib3FileData'] = field(default_factory=list)
+    dependencies: List['Mathlib3FileData'] = field(default_factory=list)
     dependent_depth: int = 0
     forward_port: Optional[ForwardPortInfo] = None
     mathlib4_history: List[FileHistoryEntry] = field(default_factory=list)

--- a/make_html.py
+++ b/make_html.py
@@ -292,8 +292,8 @@ def get_data():
             pbar.set_postfix_str(f_import.ljust(max_len), refresh=False)
             path = mathlib_dir / 'src' / Path(*f_import.split('.')).with_suffix('.lean')
 
-            if f_status.sync_prs is None:
-                f_status.sync_prs = []
+            if f_status.mathlib4_sync_prs is None:
+                f_status.mathlib4_sync_prs = []
             if f_status.labels is None:
                 f_status.labels = []
             for label in f_status.labels:

--- a/make_html.py
+++ b/make_html.py
@@ -344,10 +344,7 @@ def make_index(env, html_root):
         index_f.write(
             env.get_template('index.j2').render(
                 all=data.values(),
-                ported=ported,
-                unported=unported,
-                in_progress=in_progress,
-                text_color_of_color=text_color_of_color))
+                ported=ported, unported=unported, in_progress=in_progress))
 
 def make_out_of_sync(env, html_root, mathlib_dir):
     # Not using re.compile as this is passed to git which uses a different regex dialect:

--- a/make_html.py
+++ b/make_html.py
@@ -296,7 +296,6 @@ def get_data():
                 f_status.sync_prs = []
             if f_status.labels is None:
                 f_status.labels = []
-            # Add the text color to the dict from the yaml file which has keys `name`, `color`.
             for label in f_status.labels:
                 label.text_color = text_color_of_color(label.color)
 

--- a/port_status_yaml.py
+++ b/port_status_yaml.py
@@ -22,9 +22,9 @@ class PortStatusEntry:
     source: Optional[Source]
     mathlib4_pr: Optional[int]
     mathlib4_file: Optional[str]
-    comment: Comment = field(default_factory=Comment)
     labels: Optional[list]
     sync_prs: Optional[list]
+    comment: Comment = field(default_factory=Comment)
 
 def yaml_md_load(wikicontent: bytes):
     return yaml.safe_load(wikicontent.replace(b"```", b""))

--- a/port_status_yaml.py
+++ b/port_status_yaml.py
@@ -28,7 +28,7 @@ class PortStatusEntry:
     mathlib4_pr: Optional[int]
     mathlib4_file: Optional[str]
     labels: Optional[list[Label]]
-    sync_prs: Optional[list[int]]
+    mathlib4_sync_prs: Optional[list[int]]
     comment: Comment = field(default_factory=Comment)
 
 def yaml_md_load(wikicontent: bytes):

--- a/port_status_yaml.py
+++ b/port_status_yaml.py
@@ -8,6 +8,11 @@ import yaml
 import requests
 
 @dataclass
+class Label:
+    name: str
+    color: str
+
+@dataclass
 class PortStatusEntry:
     """ This class acts as a schema for the wiki yaml file """
     @dataclass
@@ -19,15 +24,15 @@ class PortStatusEntry:
         repo: str
         commit: str
     @dataclass
-    class Label:
-        name: str
-        color: str
+    class SyncPr:
+        num: int
+        labels: list[Label]
     ported: bool
     source: Optional[Source]
     mathlib4_pr: Optional[int]
     mathlib4_file: Optional[str]
     labels: list[Label] = field(default_factory=list)
-    mathlib4_sync_prs: list[int] = field(default_factory=list)
+    mathlib4_sync_prs: list[SyncPr] = field(default_factory=list)
     comment: Comment = field(default_factory=Comment)
 
 def yaml_md_load(wikicontent: bytes):

--- a/port_status_yaml.py
+++ b/port_status_yaml.py
@@ -23,6 +23,8 @@ class PortStatusEntry:
     mathlib4_pr: Optional[int]
     mathlib4_file: Optional[str]
     comment: Comment = field(default_factory=Comment)
+    labels: Optional[list]
+    sync_prs: Optional[list]
 
 def yaml_md_load(wikicontent: bytes):
     return yaml.safe_load(wikicontent.replace(b"```", b""))

--- a/port_status_yaml.py
+++ b/port_status_yaml.py
@@ -18,12 +18,17 @@ class PortStatusEntry:
     class Source:
         repo: str
         commit: str
+    @dataclass
+    class Label:
+        name: str
+        color: str
+        text_color: str = '000000'
     ported: bool
     source: Optional[Source]
     mathlib4_pr: Optional[int]
     mathlib4_file: Optional[str]
-    labels: Optional[list]
-    sync_prs: Optional[list]
+    labels: Optional[list[Label]]
+    sync_prs: Optional[list[int]]
     comment: Comment = field(default_factory=Comment)
 
 def yaml_md_load(wikicontent: bytes):

--- a/port_status_yaml.py
+++ b/port_status_yaml.py
@@ -22,13 +22,12 @@ class PortStatusEntry:
     class Label:
         name: str
         color: str
-        text_color: str = '000000'
     ported: bool
     source: Optional[Source]
     mathlib4_pr: Optional[int]
     mathlib4_file: Optional[str]
-    labels: Optional[list[Label]]
-    mathlib4_sync_prs: Optional[list[int]]
+    labels: list[Label] = field(default_factory=list)
+    mathlib4_sync_prs: list[int] = field(default_factory=list)
     comment: Comment = field(default_factory=Comment)
 
 def yaml_md_load(wikicontent: bytes):

--- a/templates/file.j2
+++ b/templates/file.j2
@@ -182,7 +182,7 @@ if (range != null) {
                             {%- for label in pr.labels %}
                                 <a class="badge rounded-pill"
                                     href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
-                                    style="background-color:#{{label.color}};color:{{text_color_of_color(label.color)}}">
+                                    style="background-color:#{{label.color}};color:{{label.color | text_color_of_color}}">
                                     {{label.name}}
                                 </a>
                             {%- endfor %}

--- a/templates/file.j2
+++ b/templates/file.j2
@@ -51,7 +51,7 @@
 <div class="alert alert-success">This file has been ported!</div>
 {% elif data.state == PortState.IN_PROGRESS %}
 <div class="alert alert-warning">This file is currently being ported at <a href="https://github.com/leanprover-community/mathlib4/pull/{{data.status.mathlib4_pr}}">#{{data.status.mathlib4_pr}}</a>.
-  {%- for label in data.labels %}
+  {%- for label in data.status.labels %}
   <a class="badge rounded-pill"
      href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
      style="background-color:#{{label.color}};color:{{label.color | text_color_of_color}}">

--- a/templates/file.j2
+++ b/templates/file.j2
@@ -52,24 +52,6 @@
   {%- endfor %}
 </div>
 {% endif %}
-{% if data.status.mathlib4_sync_prs %}
-    <div class="alert alert-warning">
-        This file has open sync PRs:
-        <ul>
-            {%- for pr in data.status.mathlib4_sync_prs %}
-                <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr.num}}">#{{pr.num}}</a>
-                    {%- for label in pr.labels %}
-                        <a class="badge rounded-pill"
-                            href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
-                            style="background-color:#{{label.color}};color:{{text_color_of_color(label.color)}}">
-                            {{label.name}}
-                        </a>
-                    {%- endfor %}
-                </li>
-            {%- endfor %}
-        </ul>
-    </div>
-{% endif %}
 {% if data.status.comment.message is not none %}
 <p>Before working on this file, consider the following:</p>
 <figure>
@@ -191,6 +173,22 @@ if (range != null) {
         <div class="col-lg-6">
             <h3>Changes in mathlib4</h3>
             <div>
+                {% if data.status.mathlib4_sync_prs %}
+                    <div class="alert alert-warning">
+                        This file has an open sync PR:
+                        {%- for pr in data.status.mathlib4_sync_prs %}
+                            <br />
+                            <a href="https://github.com/leanprover-community/mathlib4/pull/{{pr.num}}">#{{pr.num}}</a>
+                            {%- for label in pr.labels %}
+                                <a class="badge rounded-pill"
+                                    href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
+                                    style="background-color:#{{label.color}};color:{{text_color_of_color(label.color)}}">
+                                    {{label.name}}
+                                </a>
+                            {%- endfor %}
+                        {%- endfor %}
+                    </div>
+                {% endif %}
                 <div class="row">
                     <div class="col-1 fw-bold">mathlib3</div>
                     <div class="col-10"></div>

--- a/templates/file.j2
+++ b/templates/file.j2
@@ -52,6 +52,24 @@
   {%- endfor %}
 </div>
 {% endif %}
+{% if data.status.mathlib4_sync_prs %}
+    <div class="alert alert-warning">
+        This file has open sync PRs:
+        <ul>
+            {%- for pr in data.status.mathlib4_sync_prs %}
+                <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr.num}}">#{{pr.num}}</a>
+                    {%- for label in pr.labels %}
+                        <a class="badge rounded-pill"
+                            href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
+                            style="background-color:#{{label.color}};color:{{text_color_of_color(label.color)}}">
+                            {{label.name}}
+                        </a>
+                    {%- endfor %}
+                </li>
+            {%- endfor %}
+        </ul>
+    </div>
+{% endif %}
 {% if data.status.comment.message is not none %}
 <p>Before working on this file, consider the following:</p>
 <figure>

--- a/templates/file.j2
+++ b/templates/file.j2
@@ -256,43 +256,47 @@ cards
     {%- if parts[1] -%}{{ plus() }}<span class="text-warning" title="in progress">{{parts[1]}}</span>{%- endif -%}
     {%- if parts[2] -%}{{ plus() }}<span class="text-success" title="ported">{{parts[2]}}</span>{%- endif -%}
 </small></h2>
-{{ progress.bars([data] + data.dependencies) }}
-{% set unported_deps = ([data] + data.dependencies)|rejectattr("state", "equalto", PortState.PORTED)|list%}
-{% if unported_deps %}
-    <details style="margin-bottom: 1em">
-        <summary>Show graph</summary>
-        <svg id="graph" style="overflow-x: visible; overflow-y: clip; max-height: calc(100vh - 56px); width: 100%"></svg>
-    </details>
-    <script>
-    {% set edges, nodes = data.dep_graph_data %}
-    const edges = {{edges | tojson}};
-    const nodes = {{nodes | tojson}};
-    let svg = document.getElementById('graph');
-    let has_graphed = false;
-    svg.parentElement.addEventListener('toggle', () => {
-        if (svg.parentElement.hasAttribute('open') && !has_graphed) {
-            has_graphed = true;
-            make_graph(svg, edges, nodes);
-        }
-    })
-    </script>
-    <p>The unported dependencies are</p>
-    <ul>
-        {% for d in unported_deps %}
-            <li><a href="{{ site_url }}/file/{{d.mathlib3_import|join('/')}}"><code>{{d.mathlib3_import|join('.')}}</code></a></li>
-        {% endfor %}
-    </ul>
+{% if data.dependencies is none %}
+    Could not display informations. You might need to update your copy of `mathlib`.
 {%else%}
-<p>All dependencies are ported!</p>
-{%endif%}
-{% set unsynced_deps = data.dependencies|selectattr("forward_port.unported_commits")|list%}
-{% if unsynced_deps %}
-    <p>The following {{unsynced_deps | length}} dependencies have changed in mathlib3 since they were ported, which may complicate porting this file</p>
-    <ul>
-        {% for d in unsynced_deps %}
-            <li><a href="{{ site_url }}/file/{{d.mathlib3_import|join('/')}}"><code>{{d.mathlib3_import|join('.')}}</code></a></li>
-        {% endfor %}
-    </ul>
+    {{ progress.bars([data] + data.dependencies) }}
+    {% set unported_deps = ([data] + data.dependencies)|rejectattr("state", "equalto", PortState.PORTED)|list%}
+    {% if unported_deps %}
+        <details style="margin-bottom: 1em">
+            <summary>Show graph</summary>
+            <svg id="graph" style="overflow-x: visible; overflow-y: clip; max-height: calc(100vh - 56px); width: 100%"></svg>
+        </details>
+        <script>
+        {% set edges, nodes = data.dep_graph_data %}
+        const edges = {{edges | tojson}};
+        const nodes = {{nodes | tojson}};
+        let svg = document.getElementById('graph');
+        let has_graphed = false;
+        svg.parentElement.addEventListener('toggle', () => {
+            if (svg.parentElement.hasAttribute('open') && !has_graphed) {
+                has_graphed = true;
+                make_graph(svg, edges, nodes);
+            }
+        })
+        </script>
+        <p>The unported dependencies are</p>
+        <ul>
+            {% for d in unported_deps %}
+                <li><a href="{{ site_url }}/file/{{d.mathlib3_import|join('/')}}"><code>{{d.mathlib3_import|join('.')}}</code></a></li>
+            {% endfor %}
+        </ul>
+    {%else%}
+        <p>All dependencies are ported!</p>
+    {%endif%}
+    {% set unsynced_deps = data.dependencies|selectattr("forward_port.unported_commits")|list%}
+    {% if unsynced_deps %}
+        <p>The following {{unsynced_deps | length}} dependencies have changed in mathlib3 since they were ported, which may complicate porting this file</p>
+        <ul>
+            {% for d in unsynced_deps %}
+                <li><a href="{{ site_url }}/file/{{d.mathlib3_import|join('/')}}"><code>{{d.mathlib3_import|join('.')}}</code></a></li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 {% endif %}
 
 {% endblock %}

--- a/templates/file.j2
+++ b/templates/file.j2
@@ -257,7 +257,7 @@ cards
     {%- if parts[2] -%}{{ plus() }}<span class="text-success" title="ported">{{parts[2]}}</span>{%- endif -%}
 </small></h2>
 {% if data.dependencies is none %}
-    Could not display informations. You might need to update your copy of `mathlib`.
+    <div class="alert alert-danger">Dependency information not available. This file might be missing from the version of mathlib this website was built from.</div>
 {%else%}
     {{ progress.bars([data] + data.dependencies) }}
     {% set unported_deps = ([data] + data.dependencies)|rejectattr("state", "equalto", PortState.PORTED)|list%}

--- a/templates/file.j2
+++ b/templates/file.j2
@@ -46,7 +46,7 @@
   {%- for label in data.labels %}
   <a class="badge rounded-pill"
      href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
-     style="background-color:#{{label.color}};color:{{label.text_color}}">
+     style="background-color:#{{label.color}};color:{{label.color | text_color_of_color}}">
     {{label.name}}
   </a>
   {%- endfor %}

--- a/templates/index.j2
+++ b/templates/index.j2
@@ -46,10 +46,10 @@
                     </td>
                     <td>{{f_data.status.comment.message | htmlify_comment }}</td>
                     <td>
-                    {%- for label in f_data.labels %}
-                        <a class="badge rounded-pill" href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
-                            style="background-color:#{{label.color}};color:{{label.text_color}}">
-                            {{label.name}}
+                    {%- for label_name, label_color in f_data.status.labels %}
+                        <a class="badge rounded-pill" href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label_name}}"'
+                            style="background-color:#{{label_color}};color:{{text_color_of_color(label_color)}}">
+                            {{label_name}}
                         </a>
                     {%- endfor %}
                     </td>

--- a/templates/index.j2
+++ b/templates/index.j2
@@ -48,7 +48,7 @@
                     <td>
                     {%- for label in f_data.status.labels %}
                         <a class="badge rounded-pill" href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
-                            style="background-color:#{{label.color}};color:{{label.text_color}}">
+                            style="background-color:#{{label.color}};color:{{text_color_of_color(label.color)}}">
                             {{label.name}}
                         </a>
                     {%- endfor %}

--- a/templates/index.j2
+++ b/templates/index.j2
@@ -46,10 +46,10 @@
                     </td>
                     <td>{{f_data.status.comment.message | htmlify_comment }}</td>
                     <td>
-                    {%- for label_name, label_color, text_color in f_data.status.labels %}
-                        <a class="badge rounded-pill" href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label_name}}"'
-                            style="background-color:#{{label_color}};color:{{text_color}}">
-                            {{label_name}}
+                    {%- for label in f_data.status.labels %}
+                        <a class="badge rounded-pill" href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
+                            style="background-color:#{{label.color}};color:{{label.text_color}}">
+                            {{label.name}}
                         </a>
                     {%- endfor %}
                     </td>

--- a/templates/index.j2
+++ b/templates/index.j2
@@ -46,9 +46,9 @@
                     </td>
                     <td>{{f_data.status.comment.message | htmlify_comment }}</td>
                     <td>
-                    {%- for label_name, label_color in f_data.status.labels %}
+                    {%- for label_name, label_color, text_color in f_data.status.labels %}
                         <a class="badge rounded-pill" href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label_name}}"'
-                            style="background-color:#{{label_color}};color:{{text_color_of_color(label_color)}}">
+                            style="background-color:#{{label_color}};color:{{text_color}}">
                             {{label_name}}
                         </a>
                     {%- endfor %}

--- a/templates/index.j2
+++ b/templates/index.j2
@@ -48,7 +48,7 @@
                     <td>
                     {%- for label in f_data.status.labels %}
                         <a class="badge rounded-pill" href='https://github.com/leanprover-community/mathlib4/pulls?q=is%3Apr+is%3Aopen+label%3A"{{label.name}}"'
-                            style="background-color:#{{label.color}};color:{{text_color_of_color(label.color)}}">
+                            style="background-color:#{{label.color}};color:{{label.color | text_color_of_color}}">
                             {{label.name}}
                         </a>
                     {%- endfor %}

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -107,8 +107,8 @@ $(document).ready(function () {
             <td>{{ d.dependent_depth }}</td>
             <td>
                 <ul>
-                    {%- for pr in d.forward_port_prs %}
-                        <li><a href={{ pr.html_url }}>#{{ pr.number }}</a></li>
+                    {%- for pr in d.status.sync_prs %}
+                        <li><a href='https://github.com/leanprover-community/mathlib4/pull/"{{pr}}"'>#{{ pr }}</a></li>
                     {%- endfor %}
                 </ul>
             </td>

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -107,10 +107,11 @@ $(document).ready(function () {
                 <span class="text-success" title="added">+{{added}}</span>&nbsp;<span class="text-danger" title="removed">-{{removed}}</span>
             </td>
             <td>{{ d.dependent_depth }}</td>
-            <td data-order="{{d.status.mathlib4_sync_prs | min}}">
+            <td data-order="{{d.status.mathlib4_sync_prs | length}}">
                 <ul>
                     {%- for pr in d.status.mathlib4_sync_prs %}
-                        <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr}}">#{{pr}}</a></li>
+                        <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr.num}}"
+                            title="{%- for label in pr.labels %}{{label.name}}{{ ", " if not loop.last }}{%- endfor %}">#{{pr.num}}</a></li>
                     {%- endfor %}
                 </ul>
             </td>

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -108,12 +108,11 @@ $(document).ready(function () {
             </td>
             <td>{{ d.dependent_depth }}</td>
             <td data-order="{{d.status.mathlib4_sync_prs | length}}">
-                <ul>
-                    {%- for pr in d.status.mathlib4_sync_prs %}
-                        <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr.num}}"
-                            title="{%- for label in pr.labels %}{{label.name}}{{ ", " if not loop.last }}{%- endfor %}">#{{pr.num}}</a></li>
-                    {%- endfor %}
-                </ul>
+                {% set separator = joiner('<br />') %}
+                {%- for pr in d.status.mathlib4_sync_prs %}{{ separator() }}
+                    <a href="https://github.com/leanprover-community/mathlib4/pull/{{pr.num}}"
+                        title="{{ pr.labels | map(attribute="name") | join(", ") }}">#{{pr.num}}</a>
+                {%- endfor %}
             </td>
         </tr>
         <tr{% if not d.status.ported %} class="table-warning"{% endif %} data-is-child="true">

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -108,7 +108,7 @@ $(document).ready(function () {
             <td>
                 <ul>
                     {%- for pr in d.status.sync_prs %}
-                        <li><a href='https://github.com/leanprover-community/mathlib4/pull/"{{pr}}"'>#{{ pr }}</a></li>
+                        <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr}}">#{{ pr }}</a></li>
                     {%- endfor %}
                 </ul>
             </td>

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -50,14 +50,14 @@ $(document).ready(function () {
     let table = elem.DataTable({
         columns: [
             { class: 'dt-control', orderable: false },
-            null, null, null, null, null,
+            null, null, null, null, null, null,
         ],
     });
     elem.on('click', 'td.dt-control', function () {
         var tr = $(this).closest('tr');
         let key = $(this).children('span').data('childKey');
         var row = table.row(tr);
- 
+
         if (row.child.isShown()) {
             // This row is already open - close it
             row.child.hide();
@@ -72,14 +72,13 @@ $(document).ready(function () {
 </script>
 <div class="table-responsive"><table class="table table-sm sync-table" data-order="[[5, &quot;desc&quot;]]">
     <thead>
-        <tr>
-            <th></th>
-            <th>File</th>
-            <th>Verified at</th>
-            <th>Mathlib3 changes (newest first)</th>
-            <th>&pm;</th>
-            <th title="Length of the longest chain of mathlib3 files importing this file.">Import depth</th>
-        </tr>
+        <th></th>
+        <th>File</th>
+        <th>Verified at</th>
+        <th>Mathlib3 changes (newest first)</th>
+        <th>&pm;</th>
+        <th title="Length of the longest chain of mathlib3 files importing this file.">Import depth</th>
+        <th title="Open mathlib4-PRs with `mathlib3-pair` label touching this file.">PR</th>
     </thead>
     <tbody>
     {%- for d in needs_sync %}
@@ -106,9 +105,16 @@ $(document).ready(function () {
                 <span class="text-success" title="added">+{{added}}</span>&nbsp;<span class="text-danger" title="removed">-{{removed}}</span>
             </td>
             <td>{{ d.dependent_depth }}</td>
+            <td>
+                <ul>
+                    {%- for pr in d.forward_port_prs %}
+                        <li><a href={{ pr.html_url }}>{{ pr.number }}</a></li>
+                    {%- endfor %}
+                </ul>
+            </td>
         </tr>
         <tr{% if not d.status.ported %} class="table-warning"{% endif %} data-is-child="true">
-            <td colspan="6">
+            <td colspan="7">
                 <pre><code class="language-diff">{{ d.forward_port.diff }}</code></pre>
             </td>
         </tr>

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -107,10 +107,10 @@ $(document).ready(function () {
                 <span class="text-success" title="added">+{{added}}</span>&nbsp;<span class="text-danger" title="removed">-{{removed}}</span>
             </td>
             <td>{{ d.dependent_depth }}</td>
-            <td>
+            <td data-order="{{d.status.mathlib4_sync_prs | min}}">
                 <ul>
                     {%- for pr in d.status.mathlib4_sync_prs %}
-                        <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr}}">#{{ pr }}</a></li>
+                        <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr}}">#{{pr}}</a></li>
                     {%- endfor %}
                 </ul>
             </td>

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -72,13 +72,15 @@ $(document).ready(function () {
 </script>
 <div class="table-responsive"><table class="table table-sm sync-table" data-order="[[5, &quot;desc&quot;]]">
     <thead>
-        <th></th>
-        <th>File</th>
-        <th>Verified at</th>
-        <th>Mathlib3 changes (newest first)</th>
-        <th>&pm;</th>
-        <th title="Length of the longest chain of mathlib3 files importing this file.">Import depth</th>
-        <th title="Open mathlib4-PRs with `mathlib3-pair` label touching this file.">PR</th>
+        <tr>
+            <th></th>
+            <th>File</th>
+            <th>Verified at</th>
+            <th>Mathlib3 changes (newest first)</th>
+            <th>&pm;</th>
+            <th title="Length of the longest chain of mathlib3 files importing this file.">Import depth</th>
+            <th title="Open mathlib4-PRs with `mathlib3-pair` label touching this file.">PR</th>
+        </tr>
     </thead>
     <tbody>
     {%- for d in needs_sync %}

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -108,7 +108,7 @@ $(document).ready(function () {
             <td>
                 <ul>
                     {%- for pr in d.forward_port_prs %}
-                        <li><a href={{ pr.html_url }}>{{ pr.number }}</a></li>
+                        <li><a href={{ pr.html_url }}>#{{ pr.number }}</a></li>
                     {%- endfor %}
                 </ul>
             </td>

--- a/templates/out-of-sync.j2
+++ b/templates/out-of-sync.j2
@@ -109,7 +109,7 @@ $(document).ready(function () {
             <td>{{ d.dependent_depth }}</td>
             <td>
                 <ul>
-                    {%- for pr in d.status.sync_prs %}
+                    {%- for pr in d.status.mathlib4_sync_prs %}
                         <li><a href="https://github.com/leanprover-community/mathlib4/pull/{{pr}}">#{{ pr }}</a></li>
                     {%- endfor %}
                 </ul>


### PR DESCRIPTION
Add another column to the "out-of-sync" page that lists all open Mathlib4 PRs with label mathlib3-pair that touch the out-of-sync file.

Moreover move remaining Github API calls (for labels) to the mathlib4-script `make_port_status.py`

- [x] depends on: leanprover-community/mathlib4#2520 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/joneugster/mathlib-port-status/)