### PR TITLE
allow multiple runs in parallel

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,11 +17,6 @@ permissions:
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
   # Single deploy job since we're just deploying
   deploy:


### PR DESCRIPTION
sometimes a run is almost finished and then it is cancelled by a manual run
or worse: a manual run is cancelled by an automated run